### PR TITLE
Changing default loadable to cartridge to cartridge-skeleton

### DIFF
--- a/jenkins/jobs/dsl/CreateNewCartridge.groovy
+++ b/jenkins/jobs/dsl/CreateNewCartridge.groovy
@@ -8,7 +8,7 @@ def createNewCartridgeJob = freeStyleJob(projectFolderName + "/CreateNewCartridg
  // Setup Job 
  createNewCartridgeJob.with{
     parameters{
-            stringParam("BASE_CARTRIDGE","https://github.com/Accenture/adop-cartridge-specification.git","Git URL of the cartridge you want to base the new cartridge on.")
+            stringParam("BASE_CARTRIDGE","https://github.com/Accenture/adop-cartridge-skeleton.git","Git URL of the cartridge you want to base the new cartridge on.")
             stringParam("NEW_CARTRIDGE","my-new-cartridge","Name for your new cartridge.")
     }
     environmentVariables {


### PR DESCRIPTION
By default the CreateNewCartridge job is set to load the skeleton cartridge as a template as opposed to the cartridge specification.
